### PR TITLE
CBA settings for all AI options available

### DIFF
--- a/addons/difficulty/CfgAILevelPresets.hpp
+++ b/addons/difficulty/CfgAILevelPresets.hpp
@@ -1,10 +1,10 @@
 
-// Edit preset values below
+// precision and skillAI are maxes as they're handled via CBA settings
 #define AILEVELPRESET(x)\
 class x { \
 	displayName = "ARCOMM"; \
-	precisionAI = 0.2; \
-	skillAI = 0.7; \
+	precisionAI = 1.0; \
+	skillAI = 1.0; \
 }
 class CfgAILevelPresets {
 	// Overwriting the default presets using above macro

--- a/addons/difficulty/CfgAISkill.hpp
+++ b/addons/difficulty/CfgAISkill.hpp
@@ -2,7 +2,7 @@
 class CfgAISkill {
 	aimingAccuracy[] = {0,0,1,1};
 	aimingShake[] 	= {0,0,1,1};
-	aimingSpeed[] 	= {0,0.5,1,1};
+	aimingSpeed[] 	= {0,0,1,1}; // Default: {0,0.5,1,1}
 	commanding[] 	= {0,0,1,1};
 	courage[] 		= {0,0,1,1};
 	endurance[] 	= {0,0,1,1};

--- a/addons/difficulty/CfgEventhandlers.hpp
+++ b/addons/difficulty/CfgEventhandlers.hpp
@@ -1,0 +1,18 @@
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_Init_EventHandlers {
+	class CAManBase {
+		class ADDON {
+			init = QUOTE(call COMPILE_FILE(XEH_unitInit));
+		};
+	};
+	class LandVehicle {
+		class ADDON {
+			init = QUOTE(call COMPILE_FILE(XEH_vehicleInit));
+		};
+	};
+};

--- a/addons/difficulty/XEH_preInit.sqf
+++ b/addons/difficulty/XEH_preInit.sqf
@@ -1,0 +1,10 @@
+#include "script_component.hpp"
+
+#include "initSettings.sqf"
+
+// Global settings
+"CombatFormationSoft" enableAIFeature GVAR(CombatFormationSoft);
+"AwareFormationSoft" enableAIFeature GVAR(AwareFormationSoft);
+
+useAISteeringComponent GVAR(useAISteeringComponent);
+disableRemoteSensors GVAR(disableRemoteSensors);

--- a/addons/difficulty/XEH_unitInit.sqf
+++ b/addons/difficulty/XEH_unitInit.sqf
@@ -1,0 +1,42 @@
+#include "script_component.hpp"
+
+// See initSettings.sqf
+
+params ["_unit"];
+if (!local _unit) exitWith {};
+
+// Init group
+private _group = group _unit;
+if (
+	GVAR(enableAttack) isEqualTo 2 &&
+	{_group getVariable [QGVAR(enabled), true]} &&
+	{!(_group getVariable [QGVAR(initialized), false])}
+) then {
+	TRACE_1("Disabling attack on group", _group);
+	_group enableAttack false;
+	_group setVariable [QGVAR(initialized), true];
+};
+
+// Init unit
+if ( GVAR(enabled) && {_unit getVariable [QGVAR(enabled), true]}) then {
+	LOG_1("Setting AI skills on unit", _unit);
+
+	{
+		TRACE_2("Setting skill on unit", (_x # 0), (_x # 1));
+
+		private _randomModifier = 1 - random GVAR(randomSkill) + random GVAR(randomSkill);
+		_unit setSkill [_x # 0, (_x # 1) * _randomModifier];
+
+	} forEach [
+		["aimingAccuracy", GVAR(aimingAccuracy)],
+		["aimingSpeed", GVAR(aimingSpeed)],
+		["commanding", GVAR(commanding)],
+		["endurance", GVAR(endurance)],
+		["general", GVAR(general)],
+		["reloadSpeed", GVAR(reloadSpeed)],
+		["spotDistance", GVAR(spotDistance)],
+		["spotTime", GVAR(spotTime)],
+		["aimingShake", GVAR(aimingShake)]
+	];
+};
+_unit setVariable [QGVAR(initialized), true];

--- a/addons/difficulty/XEH_vehicleInit.sqf
+++ b/addons/difficulty/XEH_vehicleInit.sqf
@@ -1,0 +1,11 @@
+#include "script_component.hpp"
+params ["_vehicle"];
+
+// See initSettings.sqf
+
+switch (GVAR(allowCrewInImmobile)) do {
+	case 0: {}; // Default
+	case 1: {_vehicle allowCrewInImmobile true}; // Allowed
+	case 2: {_vehicle allowCrewInImmobile canFire _vehicle}; // Armed vehicles only
+	case 3: {_vehicle allowCrewInImmobile false}; // Disallowed
+};

--- a/addons/difficulty/config.cpp
+++ b/addons/difficulty/config.cpp
@@ -21,3 +21,4 @@ class CfgPatches
 #include "CfgAILevelPresets.hpp"
 #include "CFgAISkill.hpp"
 #include "CfgBrains.hpp"
+#include "CfgEventhandlers.hpp"

--- a/addons/difficulty/initSettings.sqf
+++ b/addons/difficulty/initSettings.sqf
@@ -1,0 +1,193 @@
+
+// https://community.bistudio.com/wiki/Arma_3_AI_Skill
+[
+	QGVAR(enabled),
+	"CHECKBOX",
+	["Enable AI Skill System", "Turning this off will leave AI with maxed skills. Use caution."],
+	["ARC Misc", "AI Settings"],
+	true,
+	true,
+	{},
+	true
+] call CBA_fnc_addSetting;
+
+[
+	QGVAR(aimingAccuracy),
+	"Slider",
+	["Aiming accuracy", "Affects how well AI can lead a target, compensate for recoil and dispersion"],
+	["ARC Misc", "AI Settings"],
+	[0, 1, 0.5, 2],
+	true,
+	{},
+	true
+] call CBA_fnc_addSetting;
+
+[
+	QGVAR(aimingSpeed),
+	"Slider",
+	["Aiming Speed", "Affects how quickly the AI can rotate and stabilize its aim"],
+	["ARC Misc", "AI Settings"],
+	[0, 1, 0.5, 2],
+	true,
+	{},
+	true
+] call CBA_fnc_addSetting;
+
+[
+	QGVAR(commanding),
+	"Slider",
+	["Commanding", "Affects how quickly recognized targets are shared with the group"],
+	["ARC Misc", "AI Settings"],
+	[0, 1, 0.5, 2],
+	true,
+	{},
+	true
+] call CBA_fnc_addSetting;
+
+[
+	QGVAR(endurance),
+	"Slider",
+	["Endurance", "Disabled in Arma3"],
+	["ARC Misc", "AI Settings"],
+	[0, 1, 0.5, 2],
+	true,
+	{},
+	true
+] call CBA_fnc_addSetting;
+
+[
+	QGVAR(general),
+	"Slider",
+	["General", "Raw ""Skill"", value is distributed to sub-skills unless defined otherwise. Affects the AI's decision making."],
+	["ARC Misc", "AI Settings"],
+	[0, 1, 0.5, 2],
+	true,
+	{},
+	true
+] call CBA_fnc_addSetting;
+
+[
+	QGVAR(reloadSpeed),
+	"Slider",
+	["Reload Speed", "Affects the delay between switching or reloading a weapon"],
+	["ARC Misc", "AI Settings"],
+	[0, 1, 0.5, 2],
+	true,
+	{},
+	true
+] call CBA_fnc_addSetting;
+
+[
+	QGVAR(spotDistance),
+	"Slider",
+	["Spot Distance", "Affects the AI ability to spot targets within it's visual or audible range"],
+	["ARC Misc", "AI Settings"],
+	[0, 1, 0.5, 2],
+	true,
+	{},
+	true
+] call CBA_fnc_addSetting;
+
+[
+	QGVAR(spotTime),
+	"Slider",
+	["Spot Time", "Affects how quick the AI react to death, damage or observing an enemy"],
+	["ARC Misc", "AI Settings"],
+	[0, 1, 0.5, 2],
+	true,
+	{},
+	true
+] call CBA_fnc_addSetting;
+
+[
+	QGVAR(aimingShake),
+	"Slider",
+	["Aiming Shake", "Affects how steadily the AI can hold a weapon"],
+	["ARC Misc", "AI Settings"],
+	[0, 1, 0.5, 2],
+	true,
+	{},
+	true
+] call CBA_fnc_addSetting;
+
+[
+	QGVAR(randomSkill),
+	"Slider",
+	["Random Skill %", "Applies a percentage of randomization to each skill"],
+	["ARC Misc", "AI Settings"],
+	[0, 1, 0.1, 2],
+	true,
+	{},
+	true
+] call CBA_fnc_addSetting;
+
+// https://community.bistudio.com/wiki/allowCrewInImmobile
+[
+	QGVAR(allowCrewInImmobile),
+	"LIST",
+	["Dismount immobile vehicles", "Whether units should dismount when wheels/tracks are destroyed."],
+	["ARC Misc", "AI Settings"],
+	[[0,1,2,3],["Default", "All vehicles", "Unarmed vehicles only", "No vehicles"],0],
+	true,
+	{},
+	true
+] call CBA_fnc_addSetting;
+
+// https://community.bistudio.com/wiki/enableAIFeature
+[
+	QGVAR(CombatFormationSoft),
+	"CHECKBOX",
+	"Enable CombatFormationSoft",
+	["ARC Misc", "AI Settings"],
+	true,
+	true,
+	{"CombatFormationSoft" enableAIFeature _this},
+	false
+] call CBA_fnc_addSetting;
+
+[
+	QGVAR(AwareFormationSoft),
+	"CHECKBOX",
+	"Enable AwareFormationSoft",
+	["ARC Misc", "AI Settings"],
+	true,
+	true,
+	{"AwareFormationSoft" enableAIFeature _this},
+	false
+] call CBA_fnc_addSetting;
+
+// https://community.bistudio.com/wiki/useAISteeringComponent
+[
+	QGVAR(useAISteeringComponent),
+	"CHECKBOX",
+	["Enable useAISteeringComponent", "Disable to revert to pre-apex driving."],
+	["ARC Misc", "AI Settings"],
+	true,
+	true,
+	{useAISteeringComponent _this},
+	false
+] call CBA_fnc_addSetting;
+
+// https://community.bistudio.com/wiki/enableAttack
+[
+	QGVAR(enableAttack),
+	"LIST",
+	["Enable Attack on Groups", "Set if leader can issue attack commands to the soldiers in his group."],
+	["ARC Misc", "AI Settings"],
+	[[0,1,2],["Default", "Enabled", "Disabled"],0],
+	true,
+	{},
+	true
+] call CBA_fnc_addSetting;
+
+// https://community.bistudio.com/wiki/disableRemoteSensors
+[
+	QGVAR(disableRemoteSensors),
+	"CHECKBOX",
+	["Disable Remote Sensors", "Disables visibility raycasts on non-local units."],
+	["ARC Misc", "AI Settings"],
+	false,
+	true,
+	{disableRemoteSensors _this},
+	false
+] call CBA_fnc_addSetting;


### PR DESCRIPTION
Should make it relatively easy to make sweeping changes on a per-mission basis.

This will require configuration, as AI are currently set at 0.5 for all skills.

<details>
<summary>Added CBA options</summary>

```
force arc_misc_difficulty_aimingAccuracy = 0.5;
force arc_misc_difficulty_aimingShake = 0.5;
force arc_misc_difficulty_aimingSpeed = 0.5;
force arc_misc_difficulty_allowCrewInImmobile = 0;
force arc_misc_difficulty_AwareFormationSoft = true;
force arc_misc_difficulty_CombatFormationSoft = true;
force arc_misc_difficulty_commanding = 0.5;
force arc_misc_difficulty_disableRemoteSensors = false;
force arc_misc_difficulty_enableAttack = 0;
force arc_misc_difficulty_enabled = true;
force arc_misc_difficulty_endurance = 0.5;
force arc_misc_difficulty_general = 0.5;
force arc_misc_difficulty_randomSkill = 0.1;
force arc_misc_difficulty_reloadSpeed = 0.5;
force arc_misc_difficulty_spotDistance = 0.5;
force arc_misc_difficulty_spotTime = 0.5;
force arc_misc_difficulty_useAISteeringComponent = true;
```

</details>