### PR TITLE
Disable cookoff for vehicles

### DIFF
--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -44,11 +44,8 @@ force ace_common_checkPBOsWhitelist = "['ares','mars_server']";
 force ace_noradio_enabled = true;
 
 // ACE Cook off
-force ace_cookoff_ammoCookoffDuration = 0.3;
-force ace_cookoff_enable = 2;
-force ace_cookoff_enableAmmobox = true;
-force ace_cookoff_enableAmmoCookoff = true;
-force ace_cookoff_probabilityCoef = 1;
+force ace_cookoff_enable = 0;
+force ace_cookoff_enableAmmoCookoff = false;
 
 // ACE Crew Served Weapons
 force ace_csw_ammoHandling = 2;


### PR DESCRIPTION
After some testing, disabling cookoff appears to resolve a significant amount of vehicle damage issues, with certain vehicles being near indestructible. 
This pull request disables cookoff for vehicles, however cookoff for ammoboxes remains.