### PR TITLE
Disable ACE Keep Engine Running

### DIFF
--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -206,9 +206,6 @@ force ace_ui_allowSelectiveUI = true;
 // ACE Vehicle Lock
 force ace_vehiclelock_lockVehicleInventory = true;
 
-// ACE Vehicles
-force ace_vehicles_keepEngineRunning = true;
-
 // ACE View Distance Limiter
 force ace_viewdistance_limitViewDistance = 12000;
 


### PR DESCRIPTION
Going by popular demand. Either we disable it, or we run with it for a while longer and hope that people get used to it.