### PR TITLE
Hide skill sliders

### DIFF
--- a/addons/difficulty/Cfg3DEN.hpp
+++ b/addons/difficulty/Cfg3DEN.hpp
@@ -1,0 +1,11 @@
+class Cfg3DEN {
+	class Object {
+		class AttributeCategories {
+			class State {
+				class Attributes {
+					delete Skill;
+				};
+			};
+		};
+	};
+};

--- a/addons/difficulty/RscDisplayAttributesMan.hpp
+++ b/addons/difficulty/RscDisplayAttributesMan.hpp
@@ -1,0 +1,20 @@
+class RscControlsGroup;
+
+class RscDisplayAttributes {
+	class Controls {
+		class Content: RscControlsGroup {
+			class Controls;
+		};
+	};
+};
+
+class RscDisplayAttributesMan: RscDisplayAttributes {
+	class Controls: Controls {
+		class Content: Content {
+			class Controls: Controls {
+				delete Skill;
+				delete Skill2;
+			};
+		};
+	};
+};

--- a/addons/difficulty/config.cpp
+++ b/addons/difficulty/config.cpp
@@ -22,3 +22,5 @@ class CfgPatches
 #include "CFgAISkill.hpp"
 #include "CfgBrains.hpp"
 #include "CfgEventhandlers.hpp"
+#include "Cfg3DEN.hpp"
+#include "RscDisplayAttributesMan.hpp"


### PR DESCRIPTION
With our current tweaks to AI skill levels, the sliders are misleading and a trap that I'd like to avoid.

Fixes #56