### PR TITLE
Updated loadout: CZ_Army_2020

### DIFF
--- a/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
+++ b/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
@@ -237,7 +237,9 @@ class aar : r {
 
 class rat : r {
 	displayName = "Rifleman (AT)";
+	backPack[] = {"CUP_B_ACRScout_m95"};
 	secondaryWeapon[] = {"launch_RPG32_green_F"};
+	magazines[] = {"RPG32_F"};
 };
 
 class dm : r {

--- a/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
+++ b/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
@@ -237,9 +237,7 @@ class aar : r {
 
 class rat : r {
 	displayName = "Rifleman (AT)";
-	backPack[] = {"CUP_B_ACRScout_m95"};
-	secondaryWeapon[] = {"CUP_launch_M72A6"};
-	backpackItems[] = {"CUP_launch_M72A6"};
+	secondaryWeapon[] = {"launch_RPG32_green_F"};
 };
 
 class dm : r {


### PR DESCRIPTION
Changelog: Replaced the M72A6 LAW on the RAT kit to the RPG-32 which is more reminiscent of the RPG-75 which is a portable disposable single shot launcher with equivalent destructive power. Removed the backpack as no extra space is required anymore due to this change.