### PR TITLE
Loadouts/cz army 2020

### DIFF
--- a/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
+++ b/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
@@ -237,7 +237,9 @@ class aar : r {
 
 class rat : r {
 	displayName = "Rifleman (AT)";
+	backPack[] = {"CUP_B_ACRScout_m95"};
 	secondaryWeapon[] = {"launch_RPG32_green_F"};
+	magazines[] = {"RPG32_F"};
 };
 
 class dm : r {

--- a/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
+++ b/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
@@ -206,7 +206,7 @@ class fac : ftl {
 	};
 	magazines[] += {
 		LIST_3("CUP_18Rnd_9x19_Phantom"),
-		LIST_4("ACE_Chemlight_HiGreen")
+		LIST_4("ACE_Chemlight_HiGreen"),
 		LIST_2("CUP_1Rnd_SmokeGreen_M203"),
 		LIST_2("CUP_1Rnd_SmokeRed_M203"),
 	};

--- a/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
+++ b/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
@@ -6,7 +6,6 @@
 //		* CUP Weapons
 //		* Community Factions Project
 //		* FIR AWS(AirWeaponSystem)
-//		* ACE Crew Served Weaponry
 
 //	Reference: https://en.wikipedia.org/wiki/Military_equipment_of_the_Czech_Republic
 
@@ -435,7 +434,7 @@ class mtrtl : car {
 
 class samg : car {
 	displayName = "AA Missile Specialist";
-	secondaryWeapon[] = {"CUP_launch_9K32Strela"};
+	secondaryWeapon[] = {"CUP_launch_FIM92Stinger"};
 	magazines[] = {
 		LIST_9("CUP_30Rnd_556x45_CZ805"),
 		"HandGrenade",
@@ -445,7 +444,7 @@ class samg : car {
 
 class samag : car {
 	displayName = "AA Assistant Missile Specialist";
-	secondaryWeapon[] = {"CUP_launch_9K32Strela"};
+	secondaryWeapon[] = {"CUP_launch_FIM92Stinger"};
 	magazines[] = {
 		LIST_9("CUP_30Rnd_556x45_CZ805"),
 		"HandGrenade",

--- a/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
+++ b/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
@@ -237,9 +237,7 @@ class aar : r {
 
 class rat : r {
 	displayName = "Rifleman (AT)";
-	backPack[] = {"CUP_B_ACRScout_m95"};
-	secondaryWeapon[] = {"CUP_launch_M72A6"};
-	backpackItems[] = {"CUP_launch_M72A6"};
+	secondaryWeapon[] = {"launch_RPG32_green_F"};
 };
 
 class dm : r {

--- a/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
+++ b/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
@@ -171,7 +171,7 @@ class ftl : g {
 class sl : r {
 	displayName = "Squad Leader";
 	vest[] = {"CUP_V_CZ_vest08"};
-	backPack[] = {"CUP_B_ACRScout_m95"};
+	backPack[] = {"CUP_B_ACRPara_m95"};
 	sidearmWeapon[] = {"CUP_hgun_Phantom"};
 	magazines[] = {
 		LIST_11("CUP_30Rnd_556x45_CZ805"),
@@ -192,6 +192,7 @@ class sl : r {
 class co : sl {
 	displayName = "Platoon Leader";
 	headgear[] = {"CUP_H_CZ_Patrol_Cap"};
+	backPack[] = {"CUP_B_ACRPara_m95"};
 };
 
 class fac : ftl {
@@ -206,7 +207,6 @@ class fac : ftl {
 	};
 	magazines[] += {
 		LIST_3("CUP_18Rnd_9x19_Phantom"),
-		LIST_4("ACE_Chemlight_HiGreen"),
 		LIST_2("CUP_1Rnd_SmokeGreen_M203"),
 		LIST_2("CUP_1Rnd_SmokeRed_M203"),
 	};

--- a/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
+++ b/addons/tmf_loadouts/loadouts/cz_army_2020.hpp
@@ -6,6 +6,7 @@
 //		* CUP Weapons
 //		* Community Factions Project
 //		* FIR AWS(AirWeaponSystem)
+//		* ACE Crew Served Weaponry
 
 //	Reference: https://en.wikipedia.org/wiki/Military_equipment_of_the_Czech_Republic
 
@@ -95,15 +96,17 @@ class r : baseMan {
 class g : r {
 	displayName = "Grenadier";
 	vest[] = {"CUP_V_CZ_vest06"};
+	backPack[] = {"CUP_B_ACRScout_m95"};
 	primaryWeapon[] = {
 		"CUP_arifle_CZ805_GL_coyote",
 		"CUP_arifle_CZ805_GL"
 	};
 	magazines[] = {
-		LIST_10("CUP_30Rnd_556x45_CZ805"),
+		LIST_8("CUP_30Rnd_556x45_CZ805"),
+		LIST_2("CUP_30Rnd_TE1_Red_Tracer_556x45_CZ805"),
 		"HandGrenade",
 		"SmokeShell",
-		LIST_8("CUP_1Rnd_HEDP_M203"),
+		LIST_10("CUP_1Rnd_HEDP_M203"),
 		LIST_2("1Rnd_Smoke_Grenade_shell")
 	};
 };
@@ -192,13 +195,21 @@ class co : sl {
 	headgear[] = {"CUP_H_CZ_Patrol_Cap"};
 };
 
-class fac : co {
+class fac : ftl {
 	displayName = "Forward Air Controller";
+	headgear[] = {"CUP_H_CZ_Patrol_Cap"};
 	attachment[] = {"ace_acc_pointer_green"};
+	sidearmWeapon[] = {"CUP_hgun_Phantom"};
 	backpack[] = {"CUP_B_Kombat_Radio_Olive"};
 	backpackItems[] = {
 		FAC_GEAR ,
 		"ACRE_VHF30108"
+	};
+	magazines[] += {
+		LIST_3("CUP_18Rnd_9x19_Phantom"),
+		LIST_4("ACE_Chemlight_HiGreen")
+		LIST_2("CUP_1Rnd_SmokeGreen_M203"),
+		LIST_2("CUP_1Rnd_SmokeRed_M203"),
 	};
 	linkedItems[] = {
 		"ItemMap",
@@ -238,8 +249,8 @@ class aar : r {
 class rat : r {
 	displayName = "Rifleman (AT)";
 	backPack[] = {"CUP_B_ACRScout_m95"};
-	secondaryWeapon[] = {"launch_RPG32_green_F"};
-	magazines[] = {"RPG32_F"};
+	secondaryWeapon[] = {"CUP_launch_M72A6"};
+	backpackItems[] = {"CUP_launch_M72A6"};
 };
 
 class dm : r {
@@ -424,7 +435,7 @@ class mtrtl : car {
 
 class samg : car {
 	displayName = "AA Missile Specialist";
-	secondaryWeapon[] = {"CUP_launch_FIM92Stinger"};
+	secondaryWeapon[] = {"CUP_launch_9K32Strela"};
 	magazines[] = {
 		LIST_9("CUP_30Rnd_556x45_CZ805"),
 		"HandGrenade",
@@ -434,7 +445,7 @@ class samg : car {
 
 class samag : car {
 	displayName = "AA Assistant Missile Specialist";
-	secondaryWeapon[] = {"CUP_launch_FIM92Stinger"};
+	secondaryWeapon[] = {"CUP_launch_9K32Strela"};
 	magazines[] = {
 		LIST_9("CUP_30Rnd_556x45_CZ805"),
 		"HandGrenade",
@@ -587,7 +598,7 @@ class eng : car {
 	traits[] = {"engineer", "explosiveSpecialist"};
 	vest[] = {"CUP_V_CZ_vest18"};
 	backpack[] = {"CUP_B_ACRPara_m95"};
-	sidearmWeapon[] = {"ACE_VMM3"};
+	sidearmWeapon[] = {"ACE_VMH3"};
 	items[] += {"ACE_Clacker"};
 	backpackItems[] = {
 		"ToolKit",


### PR DESCRIPTION
Updated loadout as the previous version was not the most up-to-date file in my local drive.

Changelog is as follows:

*Added 1 HEDP to GL, normalizing loadout
*Fix'd FAC loadout to inherit from FTL/GL kit as well as adding additional smokes to supplement FAC_GEAR
*Fix'd RAT to have two M72A6s - will swap to RPG26 once released
*Swapped Stinger launcher for Strela - more authentic