### PR TITLE
Fixes n tweaks

### DIFF
--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -290,7 +290,7 @@ force grad_trenches_functions_vehicleEnvelopeDigTime = 120;
 force L_Suppress_buildup = 1.3;
 force L_Suppress_enabled = true;
 force L_Suppress_halting = false;
-force L_Suppress_intensity = 0.3;
+force L_Suppress_intensity = 0.4;
 force L_Suppress_playerSwabEnabled = true;
 force L_Suppress_recovery = 2.2;
 

--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -237,9 +237,9 @@ force acre_sys_core_automaticAntennaDirection = true;
 force acre_sys_core_fullDuplex = true;
 force acre_sys_core_ignoreAntennaDirection = true;
 force acre_sys_core_interference = false;
-force acre_sys_core_revealToAI = 1;
-force acre_sys_core_terrainLoss = 0.8;
-force acre_sys_signal_signalModel = 2;
+force acre_sys_core_revealToAI = 0.5;
+force acre_sys_core_terrainLoss = 0.5;
+force acre_sys_signal_signalModel = 1;
 
 // AI
 force cfp_autoEquipNVG = false;

--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -37,7 +37,7 @@ force ace_common_checkPBOsAction = 2;
 force ace_common_checkPBOsCheckAll = true;
 force ace_common_checkPBOsWhitelist = "['ares','mars_server']";
 force ace_noradio_enabled = true;
-force ace_parachute_hideAltimeter = true;
+force ace_parachute_hideAltimeter = false;
 
 // ACE Cook off
 force ace_cookoff_enable = 0;
@@ -241,8 +241,8 @@ force acre_sys_core_fullDuplex = true;
 force acre_sys_core_ignoreAntennaDirection = true;
 force acre_sys_core_interference = false;
 force acre_sys_core_revealToAI = 0.5;
-force acre_sys_core_terrainLoss = 0.5;
-force acre_sys_signal_signalModel = 1;
+force acre_sys_core_terrainLoss = 0.8;
+force acre_sys_signal_signalModel = 2;
 
 // AI
 force cfp_autoEquipNVG = false;

--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -61,6 +61,10 @@ force ace_frag_maxTrackPerFrame = 10;
 force ace_frag_reflectionsEnabled = true;
 force ace_frag_spallEnabled = true;
 
+// ACE G-Forces
+force ace_gforces_coef = 0.5;
+force ace_gforces_enabledFor = 1;
+
 // ACE Goggles
 force ace_goggles_effects = 0;
 
@@ -193,7 +197,6 @@ force ace_switchunits_switchToWest = false;
 
 // ACE Uncategorized
 force ace_fastroping_requireRopeItems = false;
-force ace_gforces_enabledFor = 0;
 force ace_hitreactions_minDamageToTrigger = 0.1;
 force ace_laser_dispersionCount = 1;
 force ace_microdagr_mapDataAvailable = 2;

--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -42,6 +42,7 @@ force ace_common_checkPBOsAction = 2;
 force ace_common_checkPBOsCheckAll = true;
 force ace_common_checkPBOsWhitelist = "['ares','mars_server']";
 force ace_noradio_enabled = true;
+force ace_parachute_hideAltimeter = true;
 
 // ACE Cook off
 force ace_cookoff_enable = 0;

--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -293,7 +293,7 @@ force grad_trenches_functions_vehicleEnvelopeDigTime = 120;
 force L_Suppress_buildup = 1.3;
 force L_Suppress_enabled = true;
 force L_Suppress_halting = false;
-force L_Suppress_intensity = 0.4;
+force L_Suppress_intensity = 0.3;
 force L_Suppress_playerSwabEnabled = true;
 force L_Suppress_recovery = 2.2;
 

--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -311,7 +311,6 @@ force TMF_chat_tpUsage = 3;
 force TMF_chat_whisperUsage = 3;
 force TMF_spectator_isJIPAllowed = 1;
 
-
 //STUI
 force STHud_Settings_SquadBar = true;
 force STHud_Settings_RemoveDeadViaProximity = true;

--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -65,11 +65,15 @@ force ace_frag_maxTrackPerFrame = 10;
 force ace_frag_reflectionsEnabled = true;
 force ace_frag_spallEnabled = true;
 
+// ACE Goggles
+force ace_goggles_effects = 0;
+
 // ACE Hearing
 force ace_hearing_disableEarRinging = true;
 force ace_hearing_enableCombatDeafness = false;
 force ace_hearing_enabledForZeusUnits = false;
 force ace_hearing_unconsciousnessVolume = 0.4;
+force ace_hearing_autoAddEarplugsToUnits = false;
 
 // ACE Interaction
 force ace_interaction_disableNegativeRating = false;

--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -48,7 +48,7 @@ force ace_cookoff_enable = 0;
 force ace_cookoff_enableAmmoCookoff = false;
 
 // ACE Crew Served Weapons
-force ace_csw_ammoHandling = 2;
+force ace_csw_ammoHandling = 1;
 force ace_csw_defaultAssemblyMode = true;
 force ace_csw_handleExtraMagazines = true;
 force ace_csw_progressBarTimeCoefficent = 1;
@@ -306,6 +306,8 @@ force TMF_chat_rpUsage = 3;
 force TMF_chat_specUsage = 3;
 force TMF_chat_tpUsage = 3;
 force TMF_chat_whisperUsage = 3;
+force TMF_spectator_isJIPAllowed = 1;
+
 
 //STUI
 force STHud_Settings_SquadBar = true;

--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -20,11 +20,6 @@ force ace_advanced_throwing_enabled = true;
 force ace_advanced_throwing_enablePickUp = true;
 force ace_advanced_throwing_enablePickUpAttached = true;
 
-// ACE Arsenal
-force ace_arsenal_allowDefaultLoadouts = true;
-force ace_arsenal_allowSharedLoadouts = true;
-force ace_arsenal_enableIdentityTabs = false;
-
 // ACE Artillery
 force ace_artillerytables_advancedCorrections = true;
 force ace_artillerytables_disableArtilleryComputer = true;

--- a/addons/usm_tweaks/CfgVehicles.hpp
+++ b/addons/usm_tweaks/CfgVehicles.hpp
@@ -15,6 +15,7 @@ class CfgVehicles {
 	};
 	class usm_pack_m5_medic: Bag_Base {
 		delete TransportMagazines;
+		delete TransportItems;
 	};
 	class usm_pack_st138_prc77: Bag_Base {
 		maximumLoad = 120;


### PR DESCRIPTION
* Changed ACRE signal mode from multi-path to simple LOS (Multi-path seems to be about as unstable and unreliable as in real life 🤔)
* Reduced AI hearing distance (Should hopefully get less people complaining about them seeing through bushes)
* Fixed medical items being in USM backpack by default (@AChesheireCat) 
* Disable CSW ammo handling for AI, should now be able to properly use statics
* Force hide vanilla parachute altimeter. Disabled by default, but now it is forced.
* G-Forces enabled at 50% strength. Previously disabled due to not being able to tweak the strength, either being off or on.
* Increased suppression intensity from 0.3 > 0.4
* Enable changing insignia and face in arsenal, and sharing loadouts. Don't see a reason to have it disabled.
* Enable JIP at all times (@Feebee21)