### PR TITLE
Hide duplicate weapons, ammo, add AK12 545

### DIFF
--- a/addons/weapons/CfgMagazines.hpp
+++ b/addons/weapons/CfgMagazines.hpp
@@ -1,5 +1,7 @@
 class CfgMagazines {
-	class 150Rnd_762x51_Box;
+	class CA_Magazine;
+	HIDE(150Rnd_762x51_Box,CA_Magazine);
+	HIDE(150Rnd_762x51_Box_Tracer,150Rnd_762x51_Box);
 	HIDE(150Rnd_762x54_Box,150Rnd_762x51_Box);
 	HIDE(150Rnd_762x54_Box_Tracer,150Rnd_762x54_Box);
 	HIDE(ACE_150Rnd_762x54_Box_red,150Rnd_762x54_Box);
@@ -7,7 +9,6 @@ class CfgMagazines {
 	HIDE(ACE_150Rnd_762x54_Box_tracer_red,150Rnd_762x54_Box);
 	HIDE(ACE_150Rnd_762x54_Box_tracer_yellow,150Rnd_762x54_Box);
 
-	class CA_Magazine;
 	HIDE(200Rnd_556x45_Box_F,CA_Magazine);
 	HIDE(200Rnd_556x45_Box_Red_F,200Rnd_556x45_Box_F);
 	HIDE(200Rnd_556x45_Box_Tracer_F,200Rnd_556x45_Box_F);

--- a/addons/weapons/CfgMagazines.hpp
+++ b/addons/weapons/CfgMagazines.hpp
@@ -1,0 +1,25 @@
+class CfgMagazines {
+	class 150Rnd_762x51_Box;
+	HIDE(150Rnd_762x54_Box,150Rnd_762x51_Box);
+	HIDE(150Rnd_762x54_Box_Tracer,150Rnd_762x54_Box);
+	HIDE(ACE_150Rnd_762x54_Box_red,150Rnd_762x54_Box);
+	HIDE(ACE_150Rnd_762x54_Box_yellow,150Rnd_762x54_Box);
+	HIDE(ACE_150Rnd_762x54_Box_tracer_red,150Rnd_762x54_Box);
+	HIDE(ACE_150Rnd_762x54_Box_tracer_yellow,150Rnd_762x54_Box);
+
+	class CA_Magazine;
+	HIDE(200Rnd_556x45_Box_F,CA_Magazine);
+	HIDE(200Rnd_556x45_Box_Red_F,200Rnd_556x45_Box_F);
+	HIDE(200Rnd_556x45_Box_Tracer_F,200Rnd_556x45_Box_F);
+	HIDE(200Rnd_556x45_Box_Tracer_Red_F,200Rnd_556x45_Box_Tracer_F);
+	HIDE(ACE_200Rnd_556x45_Box_green,200Rnd_556x45_Box_F);
+	HIDE(ACE_200Rnd_556x45_Box_tracer_green,200Rnd_556x45_Box_Tracer_F);
+
+	class CA_LauncherMagazine;
+	HIDE(MRAWS_HEAT_F,CA_LauncherMagazine);
+	HIDE(MRAWS_HEAT55_F,MRAWS_HEAT_F);
+	HIDE(MRAWS_HE_F,MRAWS_HEAT_F);
+
+	class RPG32_F;
+	HIDE(RPG7_F,RPG32_F);
+};

--- a/addons/weapons/CfgWeapons.hpp
+++ b/addons/weapons/CfgWeapons.hpp
@@ -1,4 +1,6 @@
 class CfgWeapons {
+	class Launcher_Base_F;
+
 	class LMG_Zafir_F;
 	class GVAR(Negev_NG5): LMG_Zafir_F {
 		displayName = "Negev NG5";
@@ -38,4 +40,186 @@ class CfgWeapons {
 			"CUP_50Rnd_556x45_Green_Tracer_Galil_Mag"
 		};
 	};
+
+	class arifle_AK12_F;
+	class GVAR(ak12): arifle_AK12_F {
+		displayName = "AK-12";
+		descriptionShort = "Assault Rifle<br />Caliber: 5.45x39 mm";
+
+		baseWeapon = QGVAR(ak12);
+
+		recoil = "Recoil_CUP_AK107";
+
+		magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK", "AK_545x39"};
+		magazines[] = AK74_MAGS;
+	};
+	class arifle_AK12_arid_F;
+	class GVAR(ak12_arid): arifle_AK12_arid_F {
+		displayName = "AK-12 (Arid)";
+		descriptionShort = "Assault Rifle<br />Caliber: 5.45x39 mm";
+
+		baseWeapon = QGVAR(ak12_arid);
+
+		recoil = "Recoil_CUP_AK107";
+
+		magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK", "AK_545x39"};
+		magazines[] = AK74_MAGS;
+	};
+	class arifle_AK12_lush_F;
+	class GVAR(ak12_lush): arifle_AK12_lush_F {
+		displayName = "AK-12 (Lush)";
+		descriptionShort = "Assault Rifle<br />Caliber: 5.45x39 mm";
+
+		baseWeapon = QGVAR(ak12_lush);
+
+		recoil = "Recoil_CUP_AK107";
+
+		magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK", "AK_545x39"};
+		magazines[] = AK74_MAGS;
+	};
+
+	class arifle_AK12_GL_F;
+	class GVAR(ak12_GL): arifle_AK12_GL_F {
+		displayName = "AK-12 GL";
+		descriptionShort = "Assault Rifle<br />Caliber: 5.45x39 mm";
+
+		baseWeapon = QGVAR(ak12_GL);
+
+		recoil = "Recoil_CUP_AK107_HG";
+
+		magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK", "AK_545x39"};
+		magazines[] = AK74_MAGS;
+	};
+	class arifle_AK12_GL_arid_F;
+	class GVAR(ak12_GL_arid): arifle_AK12_GL_arid_F {
+		displayName = "AK-12 GL (Arid)";
+		descriptionShort = "Assault Rifle<br />Caliber: 5.45x39 mm";
+
+		baseWeapon = QGVAR(ak12_GL_arid);
+
+		recoil = "Recoil_CUP_AK107_HG";
+
+		magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK", "AK_545x39"};
+		magazines[] = AK74_MAGS;
+	};
+	class arifle_AK12_GL_lush_F;
+	class GVAR(ak12_GL_lush): arifle_AK12_GL_lush_F {
+		displayName = "AK-12 GL (Lush)";
+		descriptionShort = "Assault Rifle<br />Caliber: 5.45x39 mm";
+
+		baseWeapon = QGVAR(ak12_GL_lush);
+
+		recoil = "Recoil_CUP_AK107_HG";
+
+		magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK", "AK_545x39"};
+		magazines[] = AK74_MAGS;
+	};
+
+	class arifle_AK12U_F;
+	class GVAR(ak12k): arifle_AK12U_F {
+		displayName = "AK-12K";
+		descriptionShort = "Assault Rifle<br />Caliber: 5.45x39 mm";
+
+		baseWeapon = QGVAR(ak12k);
+
+		recoil = "Recoil_CUP_AK105";
+
+		magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK", "AK_545x39"};
+		magazines[] = AK74_MAGS;
+	};
+	class arifle_AK12U_arid_F;
+	class GVAR(ak12k_arid): arifle_AK12U_arid_F {
+		displayName = "AK-12K (Arid)";
+		descriptionShort = "Assault Rifle<br />Caliber: 5.45x39 mm";
+
+		baseWeapon = QGVAR(arifle_AK12U_lush_F);
+
+		recoil = "Recoil_CUP_AK105";
+
+		magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK", "AK_545x39"};
+		magazines[] = AK74_MAGS;
+	};
+	class arifle_AK12U_lush_F;
+	class GVAR(ak12k_lush): arifle_AK12U_lush_F {
+		displayName = "AK-12K (Lush)";
+		descriptionShort = "Assault Rifle<br />Caliber: 5.45x39 mm";
+
+		baseWeapon = QGVAR(ak12k_lush);
+
+		recoil = "Recoil_CUP_AK105";
+
+		magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK", "AK_545x39"};
+		magazines[] = AK74_MAGS;
+	};
+
+	class arifle_RPK12_F;
+	class GVAR(rpk16): arifle_RPK12_F {
+		displayName = "RPK-16";
+		descriptionShort = "Assault Rifle<br />Caliber: 5.45x39 mm";
+
+		baseWeapon = QGVAR(rpk16);
+
+		recoil = "Recoil_CUP_RPK74";
+
+		magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK", "AK_545x39"};
+		magazines[] = RPK74_MAGS;
+	};
+	class arifle_RPK12_arid_F;
+	class GVAR(rpk16_arid): arifle_RPK12_arid_F {
+		displayName = "RPK-16 (Arid)";
+		descriptionShort = "Assault Rifle<br />Caliber: 5.45x39 mm";
+
+		baseWeapon = QGVAR(rpk16_arid);
+
+		recoil = "Recoil_CUP_RPK74";
+
+		magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK", "AK_545x39"};
+		magazines[] = RPK74_MAGS;
+	};
+	class arifle_RPK12_lush_F;
+	class GVAR(rpk16_lush): arifle_RPK12_lush_F {
+		displayName = "RPK-16 (Lush)";
+		descriptionShort = "Assault Rifle<br />Caliber: 5.45x39 mm";
+
+		baseWeapon = QGVAR(rpk16_lush);
+
+		recoil = "Recoil_CUP_RPK74";
+
+		magazineWell[] = {"CBA_545x39_AK", "CBA_545x39_RPK", "AK_545x39"};
+		magazines[] = RPK74_MAGS;
+	};
+
+	// Hide Duplicates
+	class arifle_AKM_base_F;
+	class arifle_AKS_base_F;
+	class LMG_03_base_F;
+	class arifle_SPAR_01_base_F;
+	class arifle_SPAR_01_GL_base_F;
+	class arifle_SPAR_02_base_F;
+	class arifle_SPAR_03_base_F;
+	class DMR_06_hunter_base_F;
+	class DMR_06_base_F;
+	class Pistol_Base_F;
+	HIDE(arifle_AKM_F,arifle_AKM_base_F);
+	HIDE(arifle_AKS_F,arifle_AKS_base_F);
+	HIDE(LMG_03_F,LMG_03_base_F);
+	HIDE(arifle_SPAR_01_blk_F,arifle_SPAR_01_base_F);
+	HIDE(arifle_SPAR_01_khk_F,arifle_SPAR_01_base_F);
+	HIDE(arifle_SPAR_01_snd_F,arifle_SPAR_01_base_F);
+	HIDE(arifle_SPAR_01_GL_blk_F,arifle_SPAR_01_GL_base_F);
+	HIDE(arifle_SPAR_01_GL_khk_F,arifle_SPAR_01_GL_base_F);
+	HIDE(arifle_SPAR_01_GL_snd_F,arifle_SPAR_01_GL_base_F);
+	HIDE(arifle_SPAR_02_blk_F,arifle_SPAR_02_base_F);
+	HIDE(arifle_SPAR_02_khk_F,arifle_SPAR_02_base_F);
+	HIDE(arifle_SPAR_02_snd_F,arifle_SPAR_02_base_F);
+	HIDE(arifle_SPAR_03_blk_F,arifle_SPAR_03_base_F);
+	HIDE(arifle_SPAR_03_khk_F,arifle_SPAR_03_base_F);
+	HIDE(arifle_SPAR_03_snd_F,arifle_SPAR_03_base_F);
+	HIDE(srifle_DMR_06_hunter_F,DMR_06_hunter_base_F);
+	HIDE(srifle_DMR_06_camo_F,DMR_06_base_F);
+	HIDE(srifle_DMR_06_olive_F,DMR_06_base_F);
+
+	HIDE(hgun_Pistol_01_F,Pistol_Base_F);
+
+	HIDE(launch_RPG7_F,Launcher_Base_F);
 };

--- a/addons/weapons/config.cpp
+++ b/addons/weapons/config.cpp
@@ -13,10 +13,13 @@ class CfgPatches
 		};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
-			"arc_misc_main"
+			"arc_misc_main",
+			"cup_weapons_loadorder",
+			"ace_ballistics"
 		};
         VERSION_CONFIG;
 	};
 };
 
 #include "CfgWeapons.hpp"
+#include "CfgMagazines.hpp"

--- a/addons/weapons/script_component.hpp
+++ b/addons/weapons/script_component.hpp
@@ -1,2 +1,84 @@
 #define COMPONENT weapons
 #include "\x\arc_misc\addons\main\script_macros.hpp"
+
+#define HIDE(x,y) class x: y {scope = 1; scopeArsenal = 0;}
+
+#define AK74_MAGS {                                    \
+	"CUP_30Rnd_545x39_AK74_plum_M",                    \
+	"CUP_30Rnd_545x39_AK_M",                           \
+	"CUP_30Rnd_Subsonic_545x39_AK_M",                  \
+	"CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M",          \
+	"CUP_30Rnd_TE1_Red_Tracer_545x39_AK_M",            \
+	"CUP_30Rnd_TE1_White_Tracer_545x39_AK_M",          \
+	"CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK_M",         \
+	"CUP_30Rnd_Subsonic_545x39_AK74_plum_M",           \
+	"CUP_30Rnd_TE1_Green_Tracer_545x39_AK74_plum_M",   \
+	"CUP_30Rnd_TE1_Red_Tracer_545x39_AK74_plum_M",     \
+	"CUP_30Rnd_TE1_White_Tracer_545x39_AK74_plum_M",   \
+	"CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK74_plum_M",  \
+	"CUP_30Rnd_545x39_AK74M_M",                        \
+	"CUP_30Rnd_Subsonic_545x39_AK74M_M",               \
+	"CUP_30Rnd_TE1_Green_Tracer_545x39_AK74M_M",       \
+	"CUP_30Rnd_TE1_Red_Tracer_545x39_AK74M_M",         \
+	"CUP_30Rnd_TE1_White_Tracer_545x39_AK74M_M",       \
+	"CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK74M_M",      \
+	"CUP_30Rnd_545x39_AK74M_camo_M",                   \
+	"CUP_30Rnd_TE1_Green_Tracer_545x39_AK_camo_M",     \
+	"CUP_30Rnd_TE1_Red_Tracer_545x39_AK_camo_M",       \
+	"CUP_30Rnd_TE1_White_Tracer_545x39_AK_camo_M",     \
+	"CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK_camo_M",    \
+	"CUP_30Rnd_545x39_AK74M_desert_M",                 \
+	"CUP_30Rnd_TE1_Green_Tracer_545x39_AK_desert_M",   \
+	"CUP_30Rnd_TE1_Red_Tracer_545x39_AK_desert_M",     \
+	"CUP_30Rnd_TE1_White_Tracer_545x39_AK_desert_M",   \
+	"CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK_desert_M",  \
+	"CUP_45Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M",    \
+	"CUP_45Rnd_TE4_LRT4_Green_Tracer_545x39_RPK74M_M", \
+	"CUP_60Rnd_545x39_AK74M_M",                        \
+	"CUP_60Rnd_TE1_Green_Tracer_545x39_AK74M_M",       \
+	"CUP_60Rnd_TE1_Red_Tracer_545x39_AK74M_M",         \
+	"CUP_60Rnd_TE1_White_Tracer_545x39_AK74M_M",       \
+	"CUP_60Rnd_TE1_Yellow_Tracer_545x39_AK74M_M",      \
+	"CUP_20Rnd_545x39_AKSU_M",                         \
+	"CUP_20Rnd_Subsonic_545x39_AKSU_M"                 \
+}
+
+#define RPK74_MAGS {                                   \
+	"CUP_60Rnd_545x39_AK74M_M",                        \
+	"CUP_30Rnd_545x39_AK74_plum_M",                    \
+	"CUP_30Rnd_545x39_AK_M",                           \
+	"CUP_30Rnd_Subsonic_545x39_AK_M",                  \
+	"CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M",          \
+	"CUP_30Rnd_TE1_Red_Tracer_545x39_AK_M",            \
+	"CUP_30Rnd_TE1_White_Tracer_545x39_AK_M",          \
+	"CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK_M",         \
+	"CUP_30Rnd_Subsonic_545x39_AK74_plum_M",           \
+	"CUP_30Rnd_TE1_Green_Tracer_545x39_AK74_plum_M",   \
+	"CUP_30Rnd_TE1_Red_Tracer_545x39_AK74_plum_M",     \
+	"CUP_30Rnd_TE1_White_Tracer_545x39_AK74_plum_M",   \
+	"CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK74_plum_M",  \
+	"CUP_30Rnd_545x39_AK74M_M",                        \
+	"CUP_30Rnd_Subsonic_545x39_AK74M_M",               \
+	"CUP_30Rnd_TE1_Green_Tracer_545x39_AK74M_M",       \
+	"CUP_30Rnd_TE1_Red_Tracer_545x39_AK74M_M",         \
+	"CUP_30Rnd_TE1_White_Tracer_545x39_AK74M_M",       \
+	"CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK74M_M",      \
+	"CUP_30Rnd_545x39_AK74M_camo_M",                   \
+	"CUP_30Rnd_TE1_Green_Tracer_545x39_AK_camo_M",     \
+	"CUP_30Rnd_TE1_Red_Tracer_545x39_AK_camo_M",       \
+	"CUP_30Rnd_TE1_White_Tracer_545x39_AK_camo_M",     \
+	"CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK_camo_M",    \
+	"CUP_30Rnd_545x39_AK74M_desert_M",                 \
+	"CUP_30Rnd_TE1_Green_Tracer_545x39_AK_desert_M",   \
+	"CUP_30Rnd_TE1_Red_Tracer_545x39_AK_desert_M",     \
+	"CUP_30Rnd_TE1_White_Tracer_545x39_AK_desert_M",   \
+	"CUP_30Rnd_TE1_Yellow_Tracer_545x39_AK_desert_M",  \
+	"CUP_45Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M",    \
+	"CUP_45Rnd_TE4_LRT4_Green_Tracer_545x39_RPK74M_M", \
+	"CUP_60Rnd_TE1_Green_Tracer_545x39_AK74M_M",       \
+	"CUP_60Rnd_TE1_Red_Tracer_545x39_AK74M_M",         \
+	"CUP_60Rnd_TE1_White_Tracer_545x39_AK74M_M",       \
+	"CUP_60Rnd_TE1_Yellow_Tracer_545x39_AK74M_M",      \
+	"CUP_20Rnd_545x39_AKSU_M",                         \
+	"CUP_20Rnd_Subsonic_545x39_AKSU_M"                 \
+}


### PR DESCRIPTION
This PR will:
* Hide duplicate Apex weapons (SPAR, M249, AK, RPG)
* Hide some associated ammo (Extremely light weight in comparison to others)
* Add RPK-16, AK-12 and AK-12K, identical to Contact/Apex but uses 545. Still needs DLC.