### PR TITLE
Updated Loadout: US_Rangers_2020

### DIFF
--- a/addons/tmf_loadouts/loadouts/US_Rangers_2020.hpp
+++ b/addons/tmf_loadouts/loadouts/US_Rangers_2020.hpp
@@ -290,6 +290,12 @@ class dm : r {
 		"hlc_acc_tlr1",
 		"optic_mrd_black"
 	};
+	items[] += {
+		"ACE_MapTools",
+		"ACE_RangeCard",
+		"ACE_Kestrel4500",
+		"ACE_ATragMX"
+	};
 	magazines[] = {
 		LIST_6("CUP_20Rnd_762x51_B_M110"),
 		LIST_3("CUP_21Rnd_9x19_M17_Coyote"),
@@ -297,9 +303,6 @@ class dm : r {
 		"SmokeShell"
 	};
 	backpackItems[] = {
-		"ACE_Kestrel4500",
-		"ACE_MapTools",
-		"ACE_ATragMX",
 		"ACE_SpottingScope",
 		"ACE_Tripod"
 	};
@@ -483,24 +486,32 @@ class sn : r {
 	vest[] = {"V_Chestrig_rgr"};
 	backpack[] = {"B_Carryall_mcamo"};
 	hmd[] = {"CUP_NVG_GPNVG_black"};
-	silencer[] = {"cup_muzzle_snds_m16_coyote"};
+	primaryWeapon[] = {"CUP_srifle_M110"};
+	attachment[] = {"cup_acc_anpeq_15"};
+	scope[] = {"cup_optic_leupoldmk4"};
+	silencer[] = {"cup_muzzle_snds_m110"};
+	bipod[] = {"cup_bipod_vltor_modpod"};
 	sidearmWeapon[] = {"CUP_hgun_Glock17_blk"};
 	sidearmAttachments[] = {
 		"optic_mrd_black",
 		"hlc_acc_tlr1"
 	};
+	items[] += {
+		"ACE_MapTools",
+		"ACE_RangeCard",
+		"ACE_Kestrel4500",
+		"ACE_ATragMX"
+	};
 	magazines[] = {
-		LIST_6("CUP_30Rnd_556x45_Stanag"),
-		LIST_2("CUP_30Rnd_556x45_Stanag_Tracer_Red"),
+		LIST_6("CUP_20Rnd_762x51_B_M110"),
 		LIST_2("HandGrenade"),
 		"SmokeShell",
 		"SmokeShellGreen",
 		LIST_3("CUP_17Rnd_9x19_glock17")
 	};
 	backpackItems[] = {
-		LIST_4("CUP_20Rnd_762x51_B_M110"),
-		"CUP_srifle_M110_ANPVS10",
-		"cup_muzzle_snds_m110"
+		"ACE_EntrenchingTool",
+		"ACE_Tripod"
 	};
 	linkedItems[] += {"ItemGPS"};
 };
@@ -511,11 +522,18 @@ class sp : r {
 	vest[] = {"V_Chestrig_rgr"};
 	backpack[] = {"CFP_Kitbag_MCam_Grn"};
 	silencer[] = {"cup_muzzle_snds_m16_coyote"};
-	items[] += {"ACE_MapTools"};
+	items[] += {
+		"ACE_MapTools",
+		"ACE_RangeCard",
+		"ACE_Kestrel4500",
+		"ACE_ATragMX"
+	};
+	magazines[] += {"Laserbatteries"};
 	backpackItems[] = {
 		LIST_4("CUP_20Rnd_762x51_B_M110"),
 		"ACE_SpottingScope",
-		"ACRE_VHF30108SPIKE"
+		"ACRE_VHF30108SPIKE",
+		"ACE_Vector"
 	};
 	linkedItems[] = {
 		"ItemMap",


### PR DESCRIPTION
Updated Sniper and Spotter loadouts to include AtragMX, Kestrel 4500, and various other amenities modern snipers would have.

Updated Sniper to actually have a sniper rifle (M110).