### PR TITLE
Updated Loadouts: ru_army_template_2020, ussr_army_1985

### DIFF
--- a/addons/tmf_loadouts/loadouts/ru_army_template_2020.hpp
+++ b/addons/tmf_loadouts/loadouts/ru_army_template_2020.hpp
@@ -6,6 +6,7 @@
 		* CUP Units
 		* CUP Weapons
 		* Wearable Antennas
+		* Community Factions Project
 
 	Note:
 		This loadout functions as a template for several different camos.
@@ -558,11 +559,11 @@ class sp : g {
 class vg : car {
 	displayName = "Vehicle Gunner";
 	goggles[] = {"default"};
-	vest[] = {"CFP_V_O_RUMVD_SURPAT"};
+	vest[] = {"CUP_V_B_PASGT_no_bags_OD"};
 	headgear[] = {"H_HelmetCrew_I"};
+	primaryWeapon[] = {};
 	sidearmWeapon[] = {"hgun_Rook40_F"};
 	magazines[] = {
-		LIST_3("CUP_30Rnd_545x39_AK74M_M"),
 		LIST_3("16Rnd_9x21_Mag"),
 		"SmokeShellPurple"
 	};
@@ -570,6 +571,10 @@ class vg : car {
 
 class vc : vg {
 	displayName = "Vehicle Commander";
+	primaryWeapon[] = { CARBINE };
+	magazines[] += {
+		LIST_3("CUP_30Rnd_545x39_AK74M_M")
+	};
 	items[] += {"ACE_microDAGR"};
 	linkedItems[] += {
 		"Binocular"
@@ -619,7 +624,7 @@ class jp : baseMan {
 	goggles[] = {"default"};
 	headgear[] = {"CUP_H_RUS_ZSH_Shield_Down"};
 	uniform[] = {"CUP_U_B_USMC_PilotOverall"};
-	vest[] = {"Aircrew_vest_2_NH"};
+	vest[] = {"CUP_V_RUS_6B45_1"};
 	backpack[] = {"ACE_NonSteerableParachute"};
 	sidearmWeapon[] = {"hgun_Rook40_F"};
 	magazines[] += {

--- a/addons/tmf_loadouts/loadouts/ru_army_template_2020.hpp
+++ b/addons/tmf_loadouts/loadouts/ru_army_template_2020.hpp
@@ -40,7 +40,7 @@
 		See CfgLoadouts for usage examples
 */
 
-// Reference: https://www.battleorder.org/rus-btr-co
+// References: https://www.battleorder.org/rus-btr-co , https://www.youtube.com/watch?v=6E2oIZ7dayc
 
 //	Created by: Freddo, AChesheireCat
 
@@ -555,13 +555,15 @@ class sp : g {
 	};
 };
 
-class vg : smg {
+class vg : car {
 	displayName = "Vehicle Gunner";
 	goggles[] = {"default"};
-	vest[] = {"CUP_V_RUS_6B45_1"};
-	headgear[] = {"H_Tank_black_F"};
+	vest[] = {"CFP_V_O_RUMVD_SURPAT"};
+	headgear[] = {"H_HelmetCrew_I"};
+	sidearmWeapon[] = {"hgun_Rook40_F"};
 	magazines[] = {
-		LIST_3("CUP_20Rnd_9x39_SP5_VSS_M"),
+		LIST_3("CUP_30Rnd_545x39_AK74M_M"),
+		LIST_3("16Rnd_9x21_Mag"),
 		"SmokeShellPurple"
 	};
 };
@@ -617,7 +619,7 @@ class jp : baseMan {
 	goggles[] = {"default"};
 	headgear[] = {"CUP_H_RUS_ZSH_Shield_Down"};
 	uniform[] = {"CUP_U_B_USMC_PilotOverall"};
-	vest[] = {"CUP_V_RUS_6B45_1"};
+	vest[] = {"Aircrew_vest_2_NH"};
 	backpack[] = {"ACE_NonSteerableParachute"};
 	sidearmWeapon[] = {"hgun_Rook40_F"};
 	magazines[] += {

--- a/addons/tmf_loadouts/loadouts/ru_army_template_2020.hpp
+++ b/addons/tmf_loadouts/loadouts/ru_army_template_2020.hpp
@@ -486,7 +486,7 @@ class mtrac : r {
 class mtrtl : car {
 	displayName = "Mortar Team Leader";
 	secondaryWeapon[] = {"ace_csw_carryMortarBaseplate"};
-	items[] = { MTR_GEAR };
+	items[] += { MTR_GEAR };
 	backPack[] = {BACKPACK_CLASS(CUP_O_RUS_Patrol_bag)};
 	backpackItems[] = {
 		LIST_3("ACE_1Rnd_82mm_Mo_HE"),

--- a/addons/tmf_loadouts/loadouts/ussr_army_1985.hpp
+++ b/addons/tmf_loadouts/loadouts/ussr_army_1985.hpp
@@ -384,18 +384,22 @@ class sp : g {
 	};
 };
 
-class vg : smg {
+class vg : car {
 	displayName = "Vehicle Gunner";
-	vest[] = {"CUP_V_CDF_6B3_2_Green"};
-	headgear[] = {"CUP_H_TK_TankerHelmet"};
+	uniform[] = {"SP_0000_Standard_BattleDressUniform_Black"};
+	vest[] = {"CUP_V_CDF_OfficerBelt"};
+	headgear[] = {"CUP_H_SLA_TankerHelmet"};
+	sidearmWeapon[] = {"CUP_hgun_Makarov"};
 	magazines[] = {
-		LIST_3("CUP_20Rnd_545x39_AKSU_M"),
+		LIST_2("CUP_30Rnd_545x39_AK_M"),
+		LIST_4("CUP_8Rnd_9x18_Makarov_M"),
 		"SmokeShellPurple"
 	};
 };
 
 class vc : vg {
 	displayName = "Vehicle Commander";
+	vest[] = {"CUP_V_CDF_OfficerBelt2"};
 	linkedItems[] += {"Binocular"};
 };
 

--- a/addons/tmf_loadouts/loadouts/ussr_army_1985.hpp
+++ b/addons/tmf_loadouts/loadouts/ussr_army_1985.hpp
@@ -389,9 +389,9 @@ class vg : car {
 	uniform[] = {"SP_0000_Standard_BattleDressUniform_Black"};
 	vest[] = {"CUP_V_CDF_OfficerBelt"};
 	headgear[] = {"CUP_H_SLA_TankerHelmet"};
+	primaryWeapon[] = {};
 	sidearmWeapon[] = {"CUP_hgun_Makarov"};
 	magazines[] = {
-		LIST_2("CUP_30Rnd_545x39_AK_M"),
 		LIST_4("CUP_8Rnd_9x18_Makarov_M"),
 		"SmokeShellPurple"
 	};
@@ -400,6 +400,10 @@ class vg : car {
 class vc : vg {
 	displayName = "Vehicle Commander";
 	vest[] = {"CUP_V_CDF_OfficerBelt2"};
+	primaryWeapon[] = {"CUP_arifle_AKS74_Early"};
+	magazines[] += {
+		LIST_2("CUP_30Rnd_545x39_AK_M")
+	};
 	linkedItems[] += {"Binocular"};
 };
 
@@ -418,7 +422,7 @@ class hc : smg {
 	headgear[] = {"CUP_H_TK_PilotHelmet"};
 	items[] += {"ACE_MapTools"};
 	magazines[] = {
-		LIST_3("CUP_20Rnd_545x39_AKSU_M"),
+		LIST_3("CUP_30Rnd_545x39_AK_M"),
 		"SmokeShellPurple"
 	};
 };

--- a/addons/tmf_loadouts/loadouts/ussr_army_1985.hpp
+++ b/addons/tmf_loadouts/loadouts/ussr_army_1985.hpp
@@ -400,9 +400,12 @@ class vg : car {
 class vc : vg {
 	displayName = "Vehicle Commander";
 	vest[] = {"CUP_V_CDF_OfficerBelt2"};
-	primaryWeapon[] = {"CUP_arifle_AKS74_Early"};
+	primaryWeapon[] = {
+		"CUP_arifle_AKS74_Early",
+		"CUP_arifle_AKS74U"
+	};
 	magazines[] += {
-		LIST_2("CUP_30Rnd_545x39_AK_M")
+		LIST_3("CUP_30Rnd_545x39_AK_M")
 	};
 	linkedItems[] += {"Binocular"};
 };

--- a/addons/tmf_loadouts/loadouts/ussr_army_1985.hpp
+++ b/addons/tmf_loadouts/loadouts/ussr_army_1985.hpp
@@ -324,7 +324,7 @@ class mtrac : r {
 class mtrtl : car {
 	displayName = "Mortar Team Leader";
 	secondaryWeapon[] = {"ace_csw_carryMortarBaseplate"};
-	items[] = { MTR_GEAR };
+	items[] += { MTR_GEAR };
 	backPack[] = {"B_Carryall_oli"};
 	backpackItems[] = {
 		LIST_4("ACE_1Rnd_82mm_Mo_HE"),


### PR DESCRIPTION
Updated vehicle kits;

ru_army_template_2020
- Changed vest to CFP_V_O_RUMVD_SURPAT for comparable stats and likeness to 6B48-1
- Changed inheritance from SMG to CAR class for accuracy (SR3M -> AK105)
- Added MP443 Grach sidearm
- Updated JP to have Aircrew_vest_2_NH vest instead

ussr_army_1985
- Changed inheritance from SMG to CAR (AKS-74U -> AKS-74)
- Changed uniform to SP_0000_Standard_BattleDressUniform_Black
- Changed vest from anachronistic body armor to SLA belts
- Added Makarov PM sidearm