### PR TITLE
Tweak disableRemoteSensors option

### DIFF
--- a/addons/difficulty/initSettings.sqf
+++ b/addons/difficulty/initSettings.sqf
@@ -214,7 +214,7 @@
 	true,
 	{
 		if !hasInterface then {
-			disableRemoteSensors _this
+			disableRemoteSensors _this;
 		};
 	},
 	false

--- a/addons/difficulty/initSettings.sqf
+++ b/addons/difficulty/initSettings.sqf
@@ -212,6 +212,10 @@
 	["ARC Misc", "AI Settings"],
 	false,
 	true,
-	{disableRemoteSensors _this},
+	{
+		if !hasInterface then {
+			disableRemoteSensors _this
+		};
+	},
 	false
 ] call CBA_fnc_addSetting;


### PR DESCRIPTION
Now only applies to clients without interface, meaning HCs and dedicated server are excluded.