### PR TITLE
Add autotest for deprecated mods

### DIFF
--- a/addons/tmf_loadouts/XEH_PREP.sqf
+++ b/addons/tmf_loadouts/XEH_PREP.sqf
@@ -1,3 +1,4 @@
 PREP(testMacros);
 PREP(testTemplate);
 PREP(testGroupNames);
+PREP(testDeprecatedMods);

--- a/addons/tmf_loadouts/autotest.hpp
+++ b/addons/tmf_loadouts/autotest.hpp
@@ -60,4 +60,7 @@ class TMF_autotest {
 	class GVAR(testGroupNames) {
 		code = QUOTE([] call FUNC(testGroupNames));
 	};
+	class GVAR(testDeprecatedMods) {
+		code = QUOTE(['@Community Factions Project (CFP)'] call FUNC(testDeprecatedMods));
+	};
 };

--- a/addons/tmf_loadouts/fnc_testDeprecatedMods.sqf
+++ b/addons/tmf_loadouts/fnc_testDeprecatedMods.sqf
@@ -1,0 +1,64 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Internal Function: arc_misc_tmf_loadouts_fnc_testDeprecatedMods
+
+Description:
+	Checks for deprecated mods, and warns if they are used.
+	Used for TMF autotest.
+
+Author:
+	Freddo
+---------------------------------------------------------------------------- */
+
+private _output = [];
+
+// Scan placed vehicles
+private _vehs = vehicles + allUnits;
+MAP(_vehs,configOf _x);
+UNIQUE(_vehs);
+FILTER(_vehs,(configSourceMod _x) in _this);
+MAP(_vehs,configName _x);
+private _deprecatedVehicles = [];
+
+if (_vehs isNotEqualTo []) then {
+	_output pushBack [0, format ["Deprecated vehicles used: %1", _vehs]];
+};
+
+// Scan present loadouts
+private _items = [];
+{
+	private _role = _x;
+
+	{
+		_items append getArray (_role >> _x);
+	} forEach [
+		"uniform",
+		"vest",
+		"backpack",
+		"headgear",
+		"goggles",
+		"hmd",
+		"primaryWeapon",
+		"scope",
+		"bipod",
+		"attachment",
+		"silencer",
+		"secondaryWeapon",
+		"secondaryAttachments",
+		"sidearmWeapon",
+		"sidearmAttachments",
+		"magazines",
+		"items",
+		"linkedItems",
+		"backpackItems"
+	];
+} forEach ([missionConfigFile >> "CfgLoadouts", 1, false] call BIS_fnc_returnChildren);
+
+UNIQUE(_items);
+FILTER(_items,(configSourceMod (_x call CBA_fnc_getItemConfig)) in _this);
+
+if (_items isNotEqualTo []) then {
+	_output pushBack [0, format ["Deprecated equipment used: %1", _items]];
+};
+
+_output


### PR DESCRIPTION
Checks mission assigngear loadouts, and vehicles. Currently set to deprecate CFP.

Resolves #121