### PR TITLE
Fix CFP folder name check

### DIFF
--- a/addons/tmf_loadouts/autotest.hpp
+++ b/addons/tmf_loadouts/autotest.hpp
@@ -61,6 +61,6 @@ class TMF_autotest {
 		code = QUOTE([] call FUNC(testGroupNames));
 	};
 	class GVAR(testDeprecatedMods) {
-		code = QUOTE(['@Community Factions Project (CFP)'] call FUNC(testDeprecatedMods));
+		code = QUOTE(['@community_factions_project_(cfp)'] call FUNC(testDeprecatedMods));
 	};
 };


### PR DESCRIPTION
Folder name changed name with last update, breaking the check.