### PR TITLE
Add Fapovo, Summa Winter, OPTRE sandboxes

### DIFF
--- a/addons/sandbox/CfgMissions.hpp
+++ b/addons/sandbox/CfgMissions.hpp
@@ -109,5 +109,25 @@ class CfgMissions {
 			SANDBOX(Tarawa Betio,fow_map_tarawa,70);
 			SANDBOX(Henderson Airfield,fow_map_henderson,71);
 		};
+
+		// OPTRE Mission Rotation
+		class DOUBLES(ADDON,OPTRE) {
+			briefingName = "ARC OPTRE Sandboxes";
+
+			// Operation Trebuchet
+			SANDBOX(Blood Gulch,blood_optre,78);
+			SANDBOX(Archipelago,optre_archipelago,80);
+			SANDBOX(Gridlock,optre_gridlock,81);
+			SANDBOX(Iberius,optre_iberius,82);
+			SANDBOX(Highlands,optre_installation04,83);
+			SANDBOX(Kholo,optre_kholo,84);
+			SANDBOX(Madrigal,optre_madrigal,85);
+			SANDBOX(Phobos,optre_phobos,86);
+			SANDBOX(Sandstorm,optre_sandstorm,87);
+			SANDBOX(Wetlands,optre_wetlands,88);
+
+			// Other
+			SANDBOX(Gao,oga_gao_terrain,79);
+		};
 	};
 };

--- a/addons/sandbox/CfgMissions.hpp
+++ b/addons/sandbox/CfgMissions.hpp
@@ -60,6 +60,8 @@ class CfgMissions {
 			SANDBOX(Kulima,kulima,40);
 			SANDBOX(Clafghan,clafghan,41);
 			SANDBOX(Aliabad,mcn_aliabad,72);
+			SANDBOX(Fapovo,fapovo,76);
+			SANDBOX(Summa Winter,tem_summawcup,77);
 		};
 
 		class DOUBLES(ADDON,GM) {

--- a/addons/sandbox/MPMissions/arc_sandbox_76.fapovo/cba_settings.sqf
+++ b/addons/sandbox/MPMissions/arc_sandbox_76.fapovo/cba_settings.sqf
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_settings.sqf"

--- a/addons/sandbox/MPMissions/arc_sandbox_76.fapovo/description.ext
+++ b/addons/sandbox/MPMissions/arc_sandbox_76.fapovo/description.ext
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_bootstrap.inc"

--- a/addons/sandbox/MPMissions/arc_sandbox_76.fapovo/mission.sqm
+++ b/addons/sandbox/MPMissions/arc_sandbox_76.fapovo/mission.sqm
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_mission.sqm"

--- a/addons/sandbox/MPMissions/arc_sandbox_77.tem_summawcup/cba_settings.sqf
+++ b/addons/sandbox/MPMissions/arc_sandbox_77.tem_summawcup/cba_settings.sqf
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_settings.sqf"

--- a/addons/sandbox/MPMissions/arc_sandbox_77.tem_summawcup/description.ext
+++ b/addons/sandbox/MPMissions/arc_sandbox_77.tem_summawcup/description.ext
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_bootstrap.inc"

--- a/addons/sandbox/MPMissions/arc_sandbox_77.tem_summawcup/mission.sqm
+++ b/addons/sandbox/MPMissions/arc_sandbox_77.tem_summawcup/mission.sqm
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_mission.sqm"

--- a/addons/sandbox/MPMissions/arc_sandbox_78.blood_optre/cba_settings.sqf
+++ b/addons/sandbox/MPMissions/arc_sandbox_78.blood_optre/cba_settings.sqf
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_settings.sqf"

--- a/addons/sandbox/MPMissions/arc_sandbox_78.blood_optre/description.ext
+++ b/addons/sandbox/MPMissions/arc_sandbox_78.blood_optre/description.ext
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_bootstrap.inc"

--- a/addons/sandbox/MPMissions/arc_sandbox_78.blood_optre/mission.sqm
+++ b/addons/sandbox/MPMissions/arc_sandbox_78.blood_optre/mission.sqm
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_mission.sqm"

--- a/addons/sandbox/MPMissions/arc_sandbox_79.oga_gao_terrain/cba_settings.sqf
+++ b/addons/sandbox/MPMissions/arc_sandbox_79.oga_gao_terrain/cba_settings.sqf
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_settings.sqf"

--- a/addons/sandbox/MPMissions/arc_sandbox_79.oga_gao_terrain/description.ext
+++ b/addons/sandbox/MPMissions/arc_sandbox_79.oga_gao_terrain/description.ext
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_bootstrap.inc"

--- a/addons/sandbox/MPMissions/arc_sandbox_79.oga_gao_terrain/mission.sqm
+++ b/addons/sandbox/MPMissions/arc_sandbox_79.oga_gao_terrain/mission.sqm
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_mission.sqm"

--- a/addons/sandbox/MPMissions/arc_sandbox_80.optre_archipelago/cba_settings.sqf
+++ b/addons/sandbox/MPMissions/arc_sandbox_80.optre_archipelago/cba_settings.sqf
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_settings.sqf"

--- a/addons/sandbox/MPMissions/arc_sandbox_80.optre_archipelago/description.ext
+++ b/addons/sandbox/MPMissions/arc_sandbox_80.optre_archipelago/description.ext
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_bootstrap.inc"

--- a/addons/sandbox/MPMissions/arc_sandbox_80.optre_archipelago/mission.sqm
+++ b/addons/sandbox/MPMissions/arc_sandbox_80.optre_archipelago/mission.sqm
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_mission.sqm"

--- a/addons/sandbox/MPMissions/arc_sandbox_81.optre_gridlock/cba_settings.sqf
+++ b/addons/sandbox/MPMissions/arc_sandbox_81.optre_gridlock/cba_settings.sqf
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_settings.sqf"

--- a/addons/sandbox/MPMissions/arc_sandbox_81.optre_gridlock/description.ext
+++ b/addons/sandbox/MPMissions/arc_sandbox_81.optre_gridlock/description.ext
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_bootstrap.inc"

--- a/addons/sandbox/MPMissions/arc_sandbox_81.optre_gridlock/mission.sqm
+++ b/addons/sandbox/MPMissions/arc_sandbox_81.optre_gridlock/mission.sqm
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_mission.sqm"

--- a/addons/sandbox/MPMissions/arc_sandbox_82.optre_iberius/cba_settings.sqf
+++ b/addons/sandbox/MPMissions/arc_sandbox_82.optre_iberius/cba_settings.sqf
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_settings.sqf"

--- a/addons/sandbox/MPMissions/arc_sandbox_82.optre_iberius/description.ext
+++ b/addons/sandbox/MPMissions/arc_sandbox_82.optre_iberius/description.ext
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_bootstrap.inc"

--- a/addons/sandbox/MPMissions/arc_sandbox_82.optre_iberius/mission.sqm
+++ b/addons/sandbox/MPMissions/arc_sandbox_82.optre_iberius/mission.sqm
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_mission.sqm"

--- a/addons/sandbox/MPMissions/arc_sandbox_83.optre_installation04/cba_settings.sqf
+++ b/addons/sandbox/MPMissions/arc_sandbox_83.optre_installation04/cba_settings.sqf
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_settings.sqf"

--- a/addons/sandbox/MPMissions/arc_sandbox_83.optre_installation04/description.ext
+++ b/addons/sandbox/MPMissions/arc_sandbox_83.optre_installation04/description.ext
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_bootstrap.inc"

--- a/addons/sandbox/MPMissions/arc_sandbox_83.optre_installation04/mission.sqm
+++ b/addons/sandbox/MPMissions/arc_sandbox_83.optre_installation04/mission.sqm
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_mission.sqm"

--- a/addons/sandbox/MPMissions/arc_sandbox_84.optre_kholo/cba_settings.sqf
+++ b/addons/sandbox/MPMissions/arc_sandbox_84.optre_kholo/cba_settings.sqf
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_settings.sqf"

--- a/addons/sandbox/MPMissions/arc_sandbox_84.optre_kholo/description.ext
+++ b/addons/sandbox/MPMissions/arc_sandbox_84.optre_kholo/description.ext
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_bootstrap.inc"

--- a/addons/sandbox/MPMissions/arc_sandbox_84.optre_kholo/mission.sqm
+++ b/addons/sandbox/MPMissions/arc_sandbox_84.optre_kholo/mission.sqm
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_mission.sqm"

--- a/addons/sandbox/MPMissions/arc_sandbox_85.optre_madrigal/cba_settings.sqf
+++ b/addons/sandbox/MPMissions/arc_sandbox_85.optre_madrigal/cba_settings.sqf
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_settings.sqf"

--- a/addons/sandbox/MPMissions/arc_sandbox_85.optre_madrigal/description.ext
+++ b/addons/sandbox/MPMissions/arc_sandbox_85.optre_madrigal/description.ext
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_bootstrap.inc"

--- a/addons/sandbox/MPMissions/arc_sandbox_85.optre_madrigal/mission.sqm
+++ b/addons/sandbox/MPMissions/arc_sandbox_85.optre_madrigal/mission.sqm
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_mission.sqm"

--- a/addons/sandbox/MPMissions/arc_sandbox_86.optre_phobos/cba_settings.sqf
+++ b/addons/sandbox/MPMissions/arc_sandbox_86.optre_phobos/cba_settings.sqf
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_settings.sqf"

--- a/addons/sandbox/MPMissions/arc_sandbox_86.optre_phobos/description.ext
+++ b/addons/sandbox/MPMissions/arc_sandbox_86.optre_phobos/description.ext
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_bootstrap.inc"

--- a/addons/sandbox/MPMissions/arc_sandbox_86.optre_phobos/mission.sqm
+++ b/addons/sandbox/MPMissions/arc_sandbox_86.optre_phobos/mission.sqm
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_mission.sqm"

--- a/addons/sandbox/MPMissions/arc_sandbox_87.optre_sandstorm/cba_settings.sqf
+++ b/addons/sandbox/MPMissions/arc_sandbox_87.optre_sandstorm/cba_settings.sqf
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_settings.sqf"

--- a/addons/sandbox/MPMissions/arc_sandbox_87.optre_sandstorm/description.ext
+++ b/addons/sandbox/MPMissions/arc_sandbox_87.optre_sandstorm/description.ext
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_bootstrap.inc"

--- a/addons/sandbox/MPMissions/arc_sandbox_87.optre_sandstorm/mission.sqm
+++ b/addons/sandbox/MPMissions/arc_sandbox_87.optre_sandstorm/mission.sqm
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_mission.sqm"

--- a/addons/sandbox/MPMissions/arc_sandbox_88.optre_wetlands/cba_settings.sqf
+++ b/addons/sandbox/MPMissions/arc_sandbox_88.optre_wetlands/cba_settings.sqf
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_settings.sqf"

--- a/addons/sandbox/MPMissions/arc_sandbox_88.optre_wetlands/description.ext
+++ b/addons/sandbox/MPMissions/arc_sandbox_88.optre_wetlands/description.ext
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_bootstrap.inc"

--- a/addons/sandbox/MPMissions/arc_sandbox_88.optre_wetlands/mission.sqm
+++ b/addons/sandbox/MPMissions/arc_sandbox_88.optre_wetlands/mission.sqm
@@ -1,0 +1,1 @@
+#include "\x\arc_misc\addons\sandbox\sandbox_mission.sqm"

--- a/addons/sandbox/sandbox_bootstrap.inc
+++ b/addons/sandbox/sandbox_bootstrap.inc
@@ -27,3 +27,11 @@ class Params {
 	#include "\a3\functions_f\Params\paramWeather.inc"
 	#include "\a3\functions_f_mp_mark\Params\paramTimeAcceleration.inc"
 };
+
+class CfgDebriefingSections {
+	class acex_killTracker {
+		title = "$STR_ACEX_KillTracker_Title";
+		variable = "acex_killTracker_outputText";
+	};
+	#include "\x\tmf\addons\adminmenu\debriefAdminLog.inc"
+};


### PR DESCRIPTION
Adds sandboxes for the following terrains:

* Fapovo
* Summa Winter
* Blood Gulch
* Archipelago
* Gridlock
* Iberius
* Highlands
* Kholo
* Madrigal
* Phobos
* Sandstorm
* Wetlands
* Gao

Resolves #132 

Also adds acex killtracker and TMF Admin menu log to debriefing