### PR TITLE
Disable ACE Medical for AI

### DIFF
--- a/addons/ace_tweaks/CfgEventHandlers.hpp
+++ b/addons/ace_tweaks/CfgEventHandlers.hpp
@@ -7,6 +7,14 @@ class Extended_Killed_EventHandlers {
 	};
 };
 
+class Extended_InitPost_EventHandlers {
+	class CAManBase {
+		class ADDON {
+			init = QUOTE(call FUNC(handleUnitSpawned));
+		};
+	};
+};
+
 class Extended_PreInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH_preInit));

--- a/addons/ace_tweaks/CfgWeapons.hpp
+++ b/addons/ace_tweaks/CfgWeapons.hpp
@@ -1,0 +1,15 @@
+class CfgWeapons {
+	class ItemCore;
+	class MedikitItem;
+	class InventoryFirstAidKitItem_Base_F;
+	class Medikit: ItemCore {
+		class ItemInfo: MedikitItem {
+			mass = 75.5;
+		};
+	};
+	class FirstAidKit: ItemCore {
+		class ItemInfo: InventoryFirstAidKitItem_Base_F {
+			mass = 8;
+		};
+	};
+};

--- a/addons/ace_tweaks/XEH_PREP.sqf
+++ b/addons/ace_tweaks/XEH_PREP.sqf
@@ -1,1 +1,2 @@
 PREP(handleVehicleDeath);
+PREP(handleUnitSpawned);

--- a/addons/ace_tweaks/config.cpp
+++ b/addons/ace_tweaks/config.cpp
@@ -12,11 +12,37 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {
 			"arc_misc_main",
-			"ace_minedetector"
+			"ace_minedetector",
+			"ace_medical",
+			"ace_medical_statemachine",
+			"ace_medical_engine"
 		};
         VERSION_CONFIG;
 	};
 };
 
+// Remove AI from statemachine
+class ACE_Medical_StateMachine {
+	list = QUOTE((call ace_common_fnc_getLocalUnits) select {isPlayer _x});
+};
+
+class ace_medical_replacementItems {
+	ItemType_401[] = {
+		{"ACE_fieldDressing", 5},
+		{"ACE_morphine", 1},
+		{"ACE_tourniquet", 2}
+	};
+	ItemType_619[] = {
+		{"ACE_fieldDressing", 20},
+		{"ACE_epinephrine", 5},
+		{"ACE_morphine", 10},
+		{"ACE_salineIV_250", 5},
+		{"ACE_salineIV_500", 1},
+		{"ACE_tourniquet", 3},
+		{"ACE_splint", 10}
+	};
+};
+
 #include "ACE_detector.hpp"
 #include "CfgEventHandlers.hpp"
+#include "CfgWeapons.hpp"

--- a/addons/ace_tweaks/fnc_handleUnitSpawned.sqf
+++ b/addons/ace_tweaks/fnc_handleUnitSpawned.sqf
@@ -1,0 +1,29 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Internal Function: ARC_MISC_ace_tweaks_fnc_handleUnitSpawned
+
+Description:
+	Init function for units.
+	Currently used to disable ACE medical for AI
+
+Parameters:
+	_unit - Object the event handler is assigned to [Object]
+
+Returns:
+	Nothing
+
+Author:
+	Freddo
+---------------------------------------------------------------------------- */
+
+params ["_unit"];
+
+if (!isPlayer _unit) then {
+	[{
+		(_this getVariable ["ace_medical_HandleDamageEHID", -1]) isNotEqualTo -1
+	}, {
+		TRACE_1("Disabling ACE Medical damage for unit", _this);
+
+		_this removeEventHandler ["HandleDamage", _this getVariable ["ace_medical_HandleDamageEHID", -1]]
+	}, _unit, 15] call CBA_fnc_waitUntilAndExecute;
+};

--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -153,7 +153,7 @@ force ace_map_gestures_onlyShowFriendlys = false;
 force ace_maptools_drawStraightLines = false;
 
 // ACE Medical
-force ace_medical_ai_enabledFor = 2;
+force ace_medical_ai_enabledFor = 0;
 force ace_medical_AIDamageThreshold = 1;
 force ace_medical_bleedingCoefficient = 1;
 force ace_medical_blood_bloodLifetime = 900;

--- a/addons/tmf_loadouts/macros.inc
+++ b/addons/tmf_loadouts/macros.inc
@@ -1,30 +1,23 @@
 /* assignGear specific macros */
 #include "\x\tmf\addons\assigngear\loadouts\macros.inc"
 
-#define MEDICAL_R \
-LIST_5("ACE_fieldDressing"), \
-LIST_1("ACE_morphine"), \
-LIST_2("ACE_tourniquet")
+#define MEDICAL_R "FirstAidKit"
 
 #define MEDICAL_CLS \
+"Medikit", \
 LIST_2("ACE_bodyBag"), \
-LIST_20("ACE_fieldDressing"), \
-LIST_10("ACE_morphine"), \
-LIST_5("ACE_salineIV_250"), \
-LIST_1("ACE_salineIV_500"), \
-LIST_5("ACE_epinephrine"), \
-LIST_5("ACE_tourniquet"), \
-LIST_10("ACE_splint")
+LIST_2("ACE_tourniquet)
+
 
 #define MEDICAL_M \
-LIST_40("ACE_fieldDressing"), \
-LIST_20("ACE_morphine"), \
-LIST_15("ACE_epinephrine"), \
-LIST_8("ACE_salineIV_500"), \
-LIST_10("ACE_salineIV_250"), \
-LIST_3("ACE_tourniquet"), \
+"Medikit", \
+LIST_20("ACE_fieldDressing"), \
+LIST_10("ACE_morphine"), \
+LIST_10("ACE_epinephrine"), \
+LIST_7("ACE_salineIV_500"), \
+LIST_5("ACE_salineIV_250"), \
 LIST_2("ACE_bodyBag"), \
-LIST_20("ACE_splint"), \
+LIST_10("ACE_splint"), \
 LIST_5("ACE_salineIV")
 
 #define MTR_GEAR \


### PR DESCRIPTION
As discussed at TH, this should make AI more responsive to damage, and clear up some server resources. It should also help alleviate some of the issues with AI being "too tanky", especially with body armour.

As vanilla medical is dependent on the use of First Aid Kits and Medikits, I've edited the medical macros to include them instead. Medikits and firstaidkits now convert into the current equivalent of `MEDICAL_R` and `MEDICAL_CLS`. To reflect this and make sure autotest reports correctly, First Aid Kits and Medikits have had their mass increased to the equivalent ACE equipment mass.