### PR TITLE
fix ACE Overheating compat for FWA SMGs

### DIFF
--- a/addons/weapons/CfgWeapons.hpp
+++ b/addons/weapons/CfgWeapons.hpp
@@ -360,4 +360,17 @@ class CfgWeapons {
 		};
 	};
 
+    class sp_fwa_rifle_base;
+
+    class sp_fwa_smg_9mm_base : sp_fwa_rifle_base {
+        ace_overheating_closedBolt = 0;
+    };
+
+    class sp_fwa_smg_sterling;
+
+    class sp_fwa_smg_mk6sterling : sp_fwa_smg_sterling { //The Sterling Mk6 Police Carbine fires from a closed bolt, unlike ever other version
+        ace_overheating_closedBolt = 1;
+    };
+
+
 };


### PR DESCRIPTION
 - FWA SMGs didn't have the bolt set properly, fix that
 - not sure what the deal is with the `include/x/tmf` update being included here, don't know where it came from, couldn't revert the changed file locally